### PR TITLE
Avoid using deprecated argument by name

### DIFF
--- a/R/error.R
+++ b/R/error.R
@@ -78,5 +78,5 @@ tri_error <- function(x) {
   call <- sys.call(-1)
   fn_name <- as_name(call[[1]])
   class <- tri_error_class(gsub("^error_", "", fn_name))
-  error_cnd(.subclass = class, message = x)
+  error_cnd(class, message = x)
 }


### PR DESCRIPTION
Hello,

`.subclass` is now `class` for consistency with other S3 constructors. https://github.com/r-lib/rlang/commit/a614734f8bb4ffaea5dbb8352c591dd3f9d7ff3d

It will keep working for a good while, so no rush, but it'd be helpful to install this patch :)