### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,5 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Collate: 'check.R' 'cpp11.R' 'error.R' 'Triangular.R'
 LinkingTo: cpp11
-SystemRequirements: C++11
 Imports: rlang (>= 0.4.11), vctrs (>= 0.3.8)
 Suggests: testthat (>= 3.0.2)


### PR DESCRIPTION
We're in the process of releasing `cpp11` to cran, and we identified that this package could benefit from this change: removing the explicit system requirements to use C++11, see this for more details: https://www.tidyverse.org/blog/2023/03/cran-checks-compiled-code/#note-regarding-systemrequirements-c11